### PR TITLE
[KNOX-248] Resolve dependency service deploys over ExternalName

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -143,7 +143,7 @@ runs:
         for repo in ${REPOS//,/ }
         do
           REPO_SERVICE=$(gha-env-variables/clean_variable.sh $repo)
-          if [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE -o=name --ignore-not-found) ]]; then
+          if [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE -o=name --ignore-not-found) ]] && [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE -o=jsonpath='{.spec.type}') == "ExternalName" ]]; then
               echo "$REPO_SERVICE service already exists in $TO_NAMESPACE" 
           elif [[ $(kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then 
               kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o json \
@@ -177,7 +177,7 @@ runs:
       # https://kubernetes.github.io/ingress-nginx/how-it-works/#when-a-reload-is-required
       run: |
         SERVICE_NAME=$(gha-env-variables/clean_variable.sh ${{ inputs.SERVICE_NAME }})
-        if [[ $(kubectl get service $SERVICE_NAME -n $TO_NAMESPACE -o=jsonpath='{.spec.type}') = "ExternalName" ]]; then
+        if [[ $(kubectl get service $SERVICE_NAME -n $TO_NAMESPACE --ignore-not-found -o=jsonpath='{.spec.type}') = "ExternalName" ]]; then
             kubectl delete service $SERVICE_NAME -n $TO_NAMESPACE
         fi
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -147,7 +147,7 @@ runs:
               echo "$REPO_SERVICE service already exists in $TO_NAMESPACE" 
           elif [[ $(kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then
               # Forces ingress-controller reload
-              kubectl delete service $REPO_SERVICE -n $FROM_NAMESPACE --ignore-not-found
+              kubectl delete service $REPO_SERVICE -n $TO_NAMESPACE --ignore-not-found
 
               kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o json \
               | jq 'del(.metadata["namespace","creationTimestamp","resourceVersion","selfLink","uid"],.spec["clusterIP","clusterIPs"],.spec.ports[].nodePort)' \

--- a/action.yaml
+++ b/action.yaml
@@ -143,7 +143,7 @@ runs:
         for repo in ${REPOS//,/ }
         do
           REPO_SERVICE=$(gha-env-variables/clean_variable.sh $repo)
-          if [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE -o=name --ignore-not-found) ]] && [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE -o=jsonpath='{.spec.type}') == "ExternalName" ]]; then
+          if [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE -o=name ) ]] && [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE --ignore-not-found -o=jsonpath='{.spec.type}') != "ExternalName" ]]; then
               echo "$REPO_SERVICE service already exists in $TO_NAMESPACE" 
           elif [[ $(kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then 
               kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o json \

--- a/action.yaml
+++ b/action.yaml
@@ -2,7 +2,7 @@ name: 'Prepare Kubernetes Namespace'
 description: 'Many applications require others to exist within the same namespace. Instead of creating many branches on other repos, this action will simply deploy an ExternalName for other services.'
 
 inputs:
-  GCP_SA_KEY: 
+  GCP_SA_KEY:
     description: 'GCP Service Account Key (JSON)'
     required: true
 
@@ -10,7 +10,7 @@ inputs:
     description: 'Google Kubernetes Engine Cluster name'
     required: true
 
-  GCP_ZONE: 
+  GCP_ZONE:
     description: 'GCP Zone'
     required: true
 
@@ -22,17 +22,17 @@ inputs:
     description: 'Top Level Domain to create subdomain on.'
     required: true
 
-  TO_NAMESPACE: 
+  TO_NAMESPACE:
     description: 'Allows to override the desired NAMESPACE variable'
     required: false
     default: ${{ github.ref_name }}
 
-  FROM_NAMESPACE: 
+  FROM_NAMESPACE:
     description: 'Allows to override the desired NAMESPACE variable'
     required: false
     default: ${{ github.event.repository.default_branch }}
 
-  SERVICE_NAME: 
+  SERVICE_NAME:
     description: 'Allows to override the desired SERVICE_NAME variable'
     required: false
     default: ${{ github.repository }}
@@ -86,7 +86,7 @@ runs:
 
     - name: Deploy Namespace
       run: |
-        cat namespace.yaml | envsubst | kubectl apply -f - 
+        cat namespace.yaml | envsubst | kubectl apply -f -
       shell: bash
       working-directory: ${{ github.action_path }}/k8s
 
@@ -143,7 +143,7 @@ runs:
         for repo in ${REPOS//,/ }
         do
           REPO_SERVICE=$(gha-env-variables/clean_variable.sh $repo)
-          if [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE -o=name ) ]] && [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE --ignore-not-found -o=jsonpath='{.spec.type}') != "ExternalName" ]]; then
+          if [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE --ignore-not-found -o=name) ]] && [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE --ignore-not-found -o=jsonpath='{.spec.type}') != "ExternalName" ]]; then
               echo "$REPO_SERVICE service already exists in $TO_NAMESPACE" 
           elif [[ $(kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then
               # Forces ingress-controller reload

--- a/action.yaml
+++ b/action.yaml
@@ -145,7 +145,10 @@ runs:
           REPO_SERVICE=$(gha-env-variables/clean_variable.sh $repo)
           if [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE -o=name ) ]] && [[ $(kubectl get service $REPO_SERVICE -n $TO_NAMESPACE --ignore-not-found -o=jsonpath='{.spec.type}') != "ExternalName" ]]; then
               echo "$REPO_SERVICE service already exists in $TO_NAMESPACE" 
-          elif [[ $(kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then 
+          elif [[ $(kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then
+              # Forces ingress-controller reload
+              kubectl delete service $REPO_SERVICE -n $FROM_NAMESPACE --ignore-not-found
+
               kubectl get service $REPO_SERVICE -n $FROM_NAMESPACE -o json \
               | jq 'del(.metadata["namespace","creationTimestamp","resourceVersion","selfLink","uid"],.spec["clusterIP","clusterIPs"],.spec.ports[].nodePort)' \
               | kubectl apply -n $TO_NAMESPACE -f -


### PR DESCRIPTION
From debugging with @nathanHotz, it was found that when a prior repo deploys via gha-k8s-namespace with no repo dependency array it will deploy all services as ExternalName services, as expected. However, if later, a different repo that does have a dependency array needs to deploy, it will be skipped because a Service already existed for that repo. 

This change checks to see if they Service is an ExternalName, in which case it will proceed in deploying a copy Service of that dependency.

First run deploying ExternalName of graphql-api: https://github.com/dmsi-io/door-config-api/runs/4744542486?check_suite_focus=true

Second run deleting ExternalName and deploying ClusterIP copy of graphql-api: https://github.com/dmsi-io/door-config-api/runs/4744661337?check_suite_focus=true