### PR TITLE
Redeploy Dependencies

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -125,7 +125,7 @@ runs:
         for repo in ${REPOS//,/ }
         do
           REPO_SERVICE=$(gha-env-variables/clean_variable.sh $repo)
-          if [[ $(kubectl get deployment $REPO_SERVICE -n $TO_NAMESPACE -o=name --ignore-not-found) ]]; then
+          if [[ $(kubectl get deployment $REPO_SERVICE -n $TO_NAMESPACE -o=name --ignore-not-found) ]] && [[ ! $(kubectl get deployment graphql-api -n=redeploy-dependencies -o=json | jq -e '.spec.template.spec.containers[0].env[].value == "gha-k8s-namespace"') ]]; then
               echo "$REPO_SERVICE deployment already exists in $TO_NAMESPACE" 
           elif [[ $(kubectl get deployment $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then
               kubectl get deployment $REPO_SERVICE -n $FROM_NAMESPACE -o json \

--- a/action.yaml
+++ b/action.yaml
@@ -130,6 +130,7 @@ runs:
           elif [[ $(kubectl get deployment $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then
               kubectl get deployment $REPO_SERVICE -n $FROM_NAMESPACE -o json \
               | jq 'del(.metadata["namespace","creationTimestamp","resourceVersion","selfLink","uid"],.status)' \
+              | jq --argjson deployFlag '{"name": "DEPLOYED_FROM","value": "gha-k8s-namespace"}' '.spec.template.spec.containers[0].env += [$deployFlag]'
               | kubectl apply -n $TO_NAMESPACE -f -
           else
               echo "$REPO_SERVICE deployment not found in $FROM_NAMESPACE"

--- a/action.yaml
+++ b/action.yaml
@@ -130,7 +130,7 @@ runs:
           elif [[ $(kubectl get deployment $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then
               kubectl get deployment $REPO_SERVICE -n $FROM_NAMESPACE -o json \
               | jq 'del(.metadata["namespace","creationTimestamp","resourceVersion","selfLink","uid"],.status)' \
-              | jq --argjson deployFlag '{"name": "DEPLOYED_FROM","value": "gha-k8s-namespace"}' '.spec.template.spec.containers[0].env += [$deployFlag]'
+              | jq --argjson deployFlag '{"name": "DEPLOYED_FROM","value": "gha-k8s-namespace"}' '.spec.template.spec.containers[0].env += [$deployFlag]' \
               | kubectl apply -n $TO_NAMESPACE -f -
           else
               echo "$REPO_SERVICE deployment not found in $FROM_NAMESPACE"

--- a/action.yaml
+++ b/action.yaml
@@ -125,7 +125,8 @@ runs:
         for repo in ${REPOS//,/ }
         do
           REPO_SERVICE=$(gha-env-variables/clean_variable.sh $repo)
-          if [[ $(kubectl get deployment $REPO_SERVICE -n $TO_NAMESPACE -o=name --ignore-not-found) ]] && [[ ! $(kubectl get deployment graphql-api -n=redeploy-dependencies -o=json | jq -e '.spec.template.spec.containers[0].env[].value == "gha-k8s-namespace"') ]]; then
+          if [[ $(kubectl get deployment $REPO_SERVICE -n=$TO_NAMESPACE -o=name --ignore-not-found) ]] && \
+             [[ $(kubectl get deployment $REPO_SERVICE -n=$TO_NAMESPACE -o=json | jq -e '.spec.template.spec.containers[0].env[].value == "gha-k8s-namespace"') == "false" ]]; then
               echo "$REPO_SERVICE deployment already exists in $TO_NAMESPACE" 
           elif [[ $(kubectl get deployment $REPO_SERVICE -n $FROM_NAMESPACE -o=name --ignore-not-found) ]]; then
               kubectl get deployment $REPO_SERVICE -n $FROM_NAMESPACE -o json \


### PR DESCRIPTION
## 📑 Description
This change will deploy dependency repos with a `DEPLOYED_FROM` flag set to `gha-k8s-namespace` to represent this action's deploy process. When the action is run again, any dependency deployment with that env flag will be redeployed from the `develop` namespace. 

This change allows any new commit push deploy cycles to always deploy the latest version of any dependency into the feature namespace.

Example Run: https://github.com/dmsi-io/customers-api/runs/5239557014?check_suite_focus=true
- In this run, `graphql-api` was previously deployed with this action and includes the DEPLOYED_FROM flag. `rest-api` on the other hand was deployed manually with a branch of the same name and thus the action does not redeploy it.